### PR TITLE
Display elm-analyse workflow errors

### DIFF
--- a/.github/workflows/elm-checks.yaml
+++ b/.github/workflows/elm-checks.yaml
@@ -30,5 +30,3 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: harehare/elm-analyse-action@v1
-        with:
-          ignore_error: true

--- a/elm-analyse.json
+++ b/elm-analyse.json
@@ -1,0 +1,6 @@
+{
+    "checks": {
+        "SingleFieldRecord": false,
+        "UnusedValueConstructor": false
+    }
+}

--- a/elm-analyse.json
+++ b/elm-analyse.json
@@ -1,6 +1,5 @@
 {
     "checks": {
-        "SingleFieldRecord": false,
         "UnusedValueConstructor": false
     }
 }

--- a/src/ReCase.elm
+++ b/src/ReCase.elm
@@ -84,7 +84,7 @@ stepSnakeCase words =
     Parser.succeed (collectTitleCaseWords words)
         |= Parser.oneOf
             [ Parser.succeed Just
-                |= snakeCaseWord { allowEnd = words /= "" }
+                |= snakeCaseWord (AllowEnd <| words /= "")
             , Parser.succeed Nothing
                 |. Parser.end
             ]
@@ -162,11 +162,11 @@ word =
 
 Must be either UPPER\_, lower\_, or digits\_. A trailing underscore is required but will be removed.
 
-Use `allowEnd = False` for the first word, which must not be the last word.
+Use `AllowEnd False` for the first word, which must not be the last word.
 
 -}
-snakeCaseWord : { allowEnd : Bool } -> Parser String
-snakeCaseWord { allowEnd } =
+snakeCaseWord : AllowEnd -> Parser String
+snakeCaseWord (AllowEnd allowEnd) =
     let
         ending =
             [ ( Parser.symbol "_", True )
@@ -182,6 +182,12 @@ snakeCaseWord { allowEnd } =
             , numberToken
             ]
         |. Parser.oneOf ending
+
+
+{-| Used to indicate whether this can be the end of a snakeCaseWord.
+-}
+type AllowEnd
+    = AllowEnd Bool
 
 
 {-| Upper case char followed by all lower case, and optionally trailing digits. E.g., "Hello" or "Hello53"


### PR DESCRIPTION
- Disable `UnusedValueConstructor` check, this is covered by elm-review anyway.
- Fix the Single Field Record error